### PR TITLE
Add necessary import for `to_json`

### DIFF
--- a/src/ext/http_request.cr
+++ b/src/ext/http_request.cr
@@ -1,4 +1,5 @@
 require "http/request"
+require "json"
 
 class HTTP::Request
   def to_json


### PR DESCRIPTION
If I add your shard in an empty project and run a basic spec, I get the following error:

```
In lib/vcr/src/ext/http_request.cr:12:7

 12 | }.to_json
        ^------
Error: undefined method 'to_json' for NamedTuple(method: String, host: String | Nil, resource: String, headers: Hash(String, Array(String)), body: String, query_params: Hash(String, String))
```

Adding `require "json"` solves the issue.