### PR TITLE
add filter_sensitive_data method

### DIFF
--- a/spec/vcr_spec.cr
+++ b/spec/vcr_spec.cr
@@ -12,4 +12,26 @@ describe VCR do
       casset_resp["id"].as_i.should eq 1
     end
   end
+
+  describe "#filter_sensitive_data!" do
+    headers = HTTP::Headers.new
+    headers["Authorization"] = "Bearer 123"
+    request = HTTP::Request.new("GET", "/?api_key=123", headers: headers)
+
+    it "should replace sensitive data in query params" do
+      VCR.filter_sensitive_data("api_key", "<API_KEY>")
+      secured_request = VCR.filter_sensitive_data!(request)
+
+      secured_request.query_params["api_key"].should eq("<API_KEY>")
+      request.query_params["api_key"].should eq("123")
+    end
+
+    it "should replace sensitive data in headers" do
+      VCR.filter_sensitive_data("Authorization", "Bearer <TOKEN>")
+      secured_request = VCR.filter_sensitive_data!(request)
+
+      secured_request.headers["Authorization"].should eq("Bearer <TOKEN>")
+      request.headers["Authorization"].should eq("Bearer 123")
+    end
+  end
 end

--- a/src/ext/http_client.cr
+++ b/src/ext/http_client.cr
@@ -20,7 +20,8 @@ class HTTP::Client
 
   private def _vcr_record(request)
     # Create an md5 for the request
-    req_md5 = Digest::MD5.hexdigest(request.to_json)
+    secured_request = VCR.filter_sensitive_data!(request)
+    req_md5 = Digest::MD5.hexdigest(secured_request.to_json)
     cassette_dir = VCR.cassette_dir
 
     # Create a dir for our cassette


### PR DESCRIPTION
I added a new setting to avoid store sensitive data in cached files.

```crystal
VCR.configure do |settings|
  settings.filter_sensitive_data["api_key"] = "<API_KEY>"
end
```

Every occurrence of `api_key` in query params or headers are substituted by the placeholder.