### PR TITLE
Fix multi-casette test runs

### DIFF
--- a/spec/vcr_spec.cr
+++ b/spec/vcr_spec.cr
@@ -15,10 +15,15 @@ describe VCR do
 
   it "switches cassette_dir when new cassette is loaded" do
     load_cassette("cassette-one") do
+      VCR.cassette_dir.should eq "spec/fixtures/vcr/cassette-one"
     end
+
     load_cassette("cassette-two") do
       VCR.cassette_dir.should eq "spec/fixtures/vcr/cassette-two"
     end
+
+    load_cassette("cassette-three")
+    VCR.cassette_dir.should eq "spec/fixtures/vcr/cassette-three"
   end
 
   describe "#filter_sensitive_data!" do

--- a/spec/vcr_spec.cr
+++ b/spec/vcr_spec.cr
@@ -13,6 +13,14 @@ describe VCR do
     end
   end
 
+  it "switches cassette_dir when new cassette is loaded" do
+    load_cassette("cassette-one") do
+    end
+    load_cassette("cassette-two") do
+      VCR.cassette_dir.should eq "spec/fixtures/vcr/cassette-two"
+    end
+  end
+
   describe "#filter_sensitive_data!" do
     headers = HTTP::Headers.new
     headers["Authorization"] = "Bearer 123"

--- a/src/vcr.cr
+++ b/src/vcr.cr
@@ -8,7 +8,6 @@ module VCR
 
   @@in_order = false
   @@sequence = 0
-  @@cassette_dir : String? = nil
 
   Habitat.create do
     setting cassette_library_dir : String = "spec/fixtures/vcr"
@@ -21,7 +20,7 @@ module VCR
   end
 
   def cassette_dir
-    @@cassette_dir ||= File.join(VCR.settings.cassette_library_dir, cassette_name.not_nil!)
+    File.join(VCR.settings.cassette_library_dir, cassette_name.not_nil!)
   end
 
   # The current sequence, calling this will increment the value


### PR DESCRIPTION
When test runs use multiple casettes, the directory was cached
We should be able to just calculate this live and be just fine
