### PR TITLE
HTTP::Request#to_json reads file content if body is a File

### DIFF
--- a/spec/fixtures/test.txt
+++ b/spec/fixtures/test.txt
@@ -1,0 +1,1 @@
+hello crystal

--- a/spec/vcr_spec.cr
+++ b/spec/vcr_spec.cr
@@ -26,6 +26,16 @@ describe VCR do
     VCR.cassette_dir.should eq "spec/fixtures/vcr/cassette-three"
   end
 
+  describe "HTTP::Request#to_json" do
+    it "returns a json string with IO body" do
+      file = File.open("spec/fixtures/test.txt")
+      headers = HTTP::Headers.new
+      headers["Content-Type"] = "text/plain"
+      request = HTTP::Request.new("POST", "http://httpbin.org/post", headers, file)
+      request.to_json.should eq("{\"method\":\"POST\",\"host\":null,\"resource\":\"http://httpbin.org/post\",\"headers\":{\"Content-Type\":[\"text/plain\"]},\"body\":\"hello crystal\\n\",\"query_params\":{}}")
+    end
+  end
+
   describe "#filter_sensitive_data!" do
     headers = HTTP::Headers.new
     headers["Authorization"] = "Bearer 123"

--- a/src/ext/http_request.cr
+++ b/src/ext/http_request.cr
@@ -8,8 +8,18 @@ class HTTP::Request
       host:         hostname,
       resource:     resource,
       headers:      headers.to_h,
-      body:         body.to_s,
+      body:         body_string,
       query_params: query_params.to_h,
     }.to_json
+  end
+
+  def body_string
+    if !body.nil? && body.is_a?(File)
+      body.as(File).gets_to_end.tap do |_|
+        body.as(File).rewind
+      end
+    else
+      body.to_s
+    end
   end
 end


### PR DESCRIPTION
If the request body is a file, we want to include the file content in the json string.
Without this, File#to_s returns the object id which is random for each test run.

Another approach is to override File#to_s

@kalinon

The same test fails without the change:
```
$ crystal spec spec/vcr_spec.cr:30
F

Failures:

  1) VCR HTTP::Request#to_json returns a json string with IO body
     Failure/Error: request.to_json.should eq("{\"method\":\"POST\",\"host\":null,\"resource\":\"http://httpbin.org/post\",\"headers\":{\"Content-Type\":[\"text/plain\"]},\"body\":\"hello crystal\\n\",\"query_params\":{}}")

       Expected: "{\"method\":\"POST\",\"host\":null,\"resource\":\"http://httpbin.org/post\",\"headers\":{\"Content-Type\":[\"text/plain\"]},\"body\":\"hello crystal\\n\",\"query_params\":{}}"
            got: "{\"method\":\"POST\",\"host\":null,\"resource\":\"http://httpbin.org/post\",\"headers\":{\"Content-Type\":[\"text/plain\"]},\"body\":\"#<File:0x7fe3a4c5cee0>\",\"query_params\":{}}"
```